### PR TITLE
Delay - Let's the movie start delayed after running command.

### DIFF
--- a/PiClosedCaptions.py
+++ b/PiClosedCaptions.py
@@ -83,7 +83,8 @@ if __name__ == "__main__":
     media_player.play()
 
     if args.delay > 0:
-        time.sleep(0.1) #wait a tiny bit before pausing, otherwise it won't pause; the time stamp will resync properly.
+        while media_player.is_playing() == 0: #loop until media player is actually playing, otherwise we'll pause before the media player starts!
+            time.sleep(0.1) 
         print("Delaying video playback by " + str(args.delay) + " seconds")
         media_player.pause() #the reason why we pause instead of just start playing is to allow the media player to show a frame, mainly to hide the raspberry pi console from showing.
         events.event_attach(vlc.EventType.MediaPlayerPlaying, StartFirstTimer, movie_start, args.signaturetime, caption_sender)

--- a/PiClosedCaptions.py
+++ b/PiClosedCaptions.py
@@ -32,6 +32,7 @@ def parse_args():
     parser.add_argument("-t","--starttime", default=0, type=float, help="time in seconds that the movie will start playing")
     parser.add_argument("-a","--aspectratio", default='', help="force to specified aspect ratio (expressed in X:Y format)")
     parser.add_argument("-g","--signaturetime", default=0, type=float, help="time in seconds to display the signature block (default: signature will never be displayed)")
+    parser.add_argument("-d","--delay", default=0, type=float, help="time in seconds to delay the playing of the video, will start as paused)")
     return parser.parse_args()
 
 if __name__ == "__main__": 
@@ -74,11 +75,20 @@ if __name__ == "__main__":
     events = media_player.event_manager()
     events.event_attach(vlc.EventType.MediaPlayerEndReached, MovieFinished, media_player)
     events.event_attach(vlc.EventType.MediaPlayerTimeChanged, SyncTimeStamp, media_player, caption_sender)
-    events.event_attach(vlc.EventType.MediaPlayerPlaying, StartFirstTimer, movie_start, args.signaturetime, caption_sender)
+    if args.delay == 0:
+        events.event_attach(vlc.EventType.MediaPlayerPlaying, StartFirstTimer, movie_start, args.signaturetime, caption_sender)
     #events.event_attach(vlc.EventType.MediaPlayerForward, FastForward, media_player, subtitle_generator)
 
     # start playing video
     media_player.play()
+
+    if args.delay > 0:
+        time.sleep(0.1) #wait a tiny bit before pausing, otherwise it won't pause; the time stamp will resync properly.
+        print("Delaying video playback by " + str(args.delay) + " seconds")
+        media_player.pause() #the reason why we pause instead of just start playing is to allow the media player to show a frame, mainly to hide the raspberry pi console from showing.
+        events.event_attach(vlc.EventType.MediaPlayerPlaying, StartFirstTimer, movie_start, args.signaturetime, caption_sender)
+        time.sleep(args.delay)
+        media_player.play()
 
     input("Press Enter to stop...")
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ These scripts were written using Python 3.7
 This script is where all the magic happens, it will play the movie and send the captions to the TV just like the glory days of analog home video.
 #### Usage Instructions
 ```bash
-python3 PiClosedCaptions.py [-h] [-s SUBFILE] [-m MOVIEFILE] [-c COMPORT] [-t STARTTIME]
+python3 PiClosedCaptions.py [-h] [-s SUBFILE] [-m MOVIEFILE] [-c COMPORT] [-t STARTTIME] [-d DELAY]
 ```
 Once the movie starts playing it can be stopped by simply pressing enter on the terminal that is running the script. The next subtitle to be displayed will be printed to the terminal as well.
 


### PR DESCRIPTION
What this does is add a new parameter, -d / --delay, which allows the movie to start very briefly before immediately pausing, giving a frozen frame to be displayed on screen. This is ideal to allow a VCR to catch up and not start recording without you, especially ideal for me since my VCR takes around 10-15 seconds to start recording.

The reason why I made this pause the video as oppose to just, not start the video yet, is to give a frozen frame on screen so that if the VCR starts recording before you expect it to, it doesn't show the Raspberry Pi's terminal screen in the recording, which although not the end of the world, isn't exactly what you wanna see when you play a VHS tape.
I personally like this because a couple of my movie files has my own self-created FBI warning screens n the such, and that's the frame that gets frozen on screen. And if the video starts with a fade-in, it just starts on a dark frame, giving another desirable result.

I'll admit it's a little bit jank since I didn't touch any of the capsender code, but I've tested this multiple times with different subtitle files and videos, and it all seems to check out fine. Additionally, this does work with -t/--starttime, though weirdly videos that use H.265 seem to act a little bit weird with that? H.264 works as expected though.